### PR TITLE
Use git version to fix exit crash in kdenlive

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,2 +1,4 @@
-sources:
+removed_sources:
   mlt-6.4.1.tar.gz: f2d946cf64fbd48485445cb6a4d604615dfc45d4
+sources:
+  mlt-20170614.tar.gz: f316d9666e5c36f854af0a86be54e798fdba7a55

--- a/mlt.spec
+++ b/mlt.spec
@@ -9,8 +9,8 @@
 
 Summary:	Media Lovin' Toolkit nonlinear video editing library
 Name:		mlt
-Version:	6.4.1
-Release:	2
+Version:	20170614
+Release:	1
 License:	LGPLv2+
 Group:		Video
 Url:		http://mlt.sourceforge.net


### PR DESCRIPTION
Please pull into 3.0 and cooker if appropriate. It fixes crash on exit of the current kdenlive.
Colin
